### PR TITLE
update ChartViewBase.lastHighlighted for ChartViewBase.highlightValue()

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -520,6 +520,8 @@ open class ChartViewBase: NSUIView, ChartDataProvider, AnimatorDelegate
         }
         else
         {
+            self.lastHighlighted = highlight
+            
             // set the indices to highlight
             entry = _data?.entryForHighlight(h!)
             if entry == nil

--- a/Source/Charts/Data/Implementations/Standard/PieChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/PieChartDataSet.swift
@@ -111,6 +111,9 @@ open class PieChartDataSet: ChartDataSet, IPieChartDataSet
     /// the color for the highlighted sector
     open var highlightColor: NSUIColor? = nil
 
+    /// the border width for the highlighted sector
+    public var highlightBorderWidth: CGFloat = 0.0
+
     // MARK: - NSCopying
 
     open override func copy(with zone: NSZone? = nil) -> Any

--- a/Source/Charts/Data/Interfaces/IPieChartDataSet.swift
+++ b/Source/Charts/Data/Interfaces/IPieChartDataSet.swift
@@ -61,4 +61,7 @@ public protocol IPieChartDataSet: IChartDataSet
     /// get/sets the color for the highlighted sector
     var highlightColor: NSUIColor? { get set }
 
+    /// gets/sets the border width for the highlighted sector
+    var highlightBorderWidth: CGFloat { get set }
+
 }

--- a/Source/Charts/Highlight/PieRadarHighlighter.swift
+++ b/Source/Charts/Highlight/PieRadarHighlighter.swift
@@ -21,12 +21,12 @@ open class PieRadarHighlighter: ChartHighlighter
         
         let touchDistanceToCenter = chart.distanceToCenter(x: x, y: y)
         
-        // check if a slice was touched
-        guard touchDistanceToCenter <= chart.radius else
-        {
-            // if no slice was touched, highlight nothing
-            return nil
-        }
+//        // check if a slice was touched
+//        guard touchDistanceToCenter <= chart.radius else
+//        {
+//            // if no slice was touched, highlight nothing
+//            return nil
+//        }
 
         var angle = chart.angleForPoint(x: x ,y: y)
 

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -758,8 +758,11 @@ open class PieChartRenderer: DataRenderer
 
             let accountForSliceSpacing = sliceSpace > 0.0 && sliceAngle <= 180.0
 
-            context.setFillColor(set.highlightColor?.cgColor ?? set.color(atIndex: index).cgColor)
-
+            context.setFillColor(set.color(atIndex: index).cgColor)
+            if let highlightColor = set.highlightColor?.cgColor {
+                context.setStrokeColor(highlightColor)
+                context.setLineWidth(3.0)
+            }
             let sliceSpaceAngleOuter = visibleAngleCount == 1 ?
                 0.0 :
                 sliceSpace / radius.DEG2RAD
@@ -860,7 +863,7 @@ open class PieChartRenderer: DataRenderer
 
             context.beginPath()
             context.addPath(path)
-            context.fillPath(using: .evenOdd)
+            context.drawPath(using: CGPathDrawingMode.eoFillStroke)
 
             let axElement = createAccessibleElement(withIndex: index,
                                                     container: chart,

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -761,7 +761,7 @@ open class PieChartRenderer: DataRenderer
             context.setFillColor(set.color(atIndex: index).cgColor)
             if let highlightColor = set.highlightColor?.cgColor {
                 context.setStrokeColor(highlightColor)
-                context.setLineWidth(3.0)
+                context.setLineWidth(set.highlightBorderWidth)
             }
             let sliceSpaceAngleOuter = visibleAngleCount == 1 ?
                 0.0 :


### PR DESCRIPTION
### Goals :soccer:
The `lastHighlighted` property of `ChartViewBase` is only set to a non-nil value within `highlightValues`(). We should set the lastHighlighted value for the singular `highlightValue`()  method as well.