### PR TITLE
Posibility to add Corner Radius for rounded bars in bar chart

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
@@ -55,7 +55,29 @@ open class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, BarChartData
     public var cornerRadius: CGFloat = 0.0
     
     /// array of corners to be rounded
-    open var roundedCorners: UIRectCorner = []
+    open var roundedCorners: UIRectCorner = [] {
+        didSet {
+            var invertedCorners: UIRectCorner = []
+            if roundedCorners.contains(.topLeft) {
+                invertedCorners.insert(.bottomLeft)
+            }
+            if roundedCorners.contains(.topRight) {
+                invertedCorners.insert(.bottomRight)
+            }
+            if roundedCorners.contains(.bottomLeft) {
+                invertedCorners.insert(.topLeft)
+            }
+            if roundedCorners.contains(.bottomRight) {
+                invertedCorners.insert(.topRight)
+            }
+            if roundedCorners.contains(.allCorners) {
+                invertedCorners.insert(.allCorners)
+            }
+            roundedCornersInverted = invertedCorners
+        }
+    }
+    
+    open var roundedCornersInverted: UIRectCorner = []
     
     /// Calculates the total number of entries this DataSet represents, including
     /// stacks. All values belonging to a stack are calculated separately.

--- a/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
@@ -77,7 +77,7 @@ open class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, BarChartData
         }
     }
     
-    open var roundedCornersInverted: UIRectCorner = []
+    open private(set) var roundedCornersInverted: UIRectCorner = []
     
     /// Calculates the total number of entries this DataSet represents, including
     /// stacks. All values belonging to a stack are calculated separately.

--- a/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/BarChartDataSet.swift
@@ -51,6 +51,12 @@ open class BarChartDataSet: BarLineScatterCandleBubbleChartDataSet, BarChartData
     /// the overall entry count, including counting each stack-value individually
     private var _entryCountStacks = 0
     
+    /// the corner radius applied to each data set
+    public var cornerRadius: CGFloat = 0.0
+    
+    /// array of corners to be rounded
+    open var roundedCorners: UIRectCorner = []
+    
     /// Calculates the total number of entries this DataSet represents, including
     /// stacks. All values belonging to a stack are calculated separately.
     private func calcEntryCountIncludingStacks(entries: [BarChartDataEntry])

--- a/Source/Charts/Data/Interfaces/BarChartDataSetProtocol.swift
+++ b/Source/Charts/Data/Interfaces/BarChartDataSetProtocol.swift
@@ -49,4 +49,7 @@ public protocol BarChartDataSetProtocol: BarLineScatterCandleBubbleChartDataSetP
     
     /// array of corners to be rounded
     var roundedCorners: UIRectCorner { get set }
+    
+    /// array of corners to be rounded
+    var roundedCornersInverted: UIRectCorner { get }
 }

--- a/Source/Charts/Data/Interfaces/BarChartDataSetProtocol.swift
+++ b/Source/Charts/Data/Interfaces/BarChartDataSetProtocol.swift
@@ -12,6 +12,10 @@
 import Foundation
 import CoreGraphics
 
+#if canImport(UIKit)
+import UIKit
+#endif
+
 @objc
 public protocol BarChartDataSetProtocol: BarLineScatterCandleBubbleChartDataSetProtocol
 {
@@ -39,4 +43,10 @@ public protocol BarChartDataSetProtocol: BarLineScatterCandleBubbleChartDataSetP
     
     /// array of labels used to describe the different values of the stacked bars
     var stackLabels: [String] { get set }
+    
+    /// the corner radius applied to each data set
+    var cornerRadius: CGFloat { get set }
+    
+    /// array of corners to be rounded
+    var roundedCorners: UIRectCorner { get set }
 }

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -352,7 +352,13 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
 
                 context.setFillColor(dataSet.barShadowColor.cgColor)
                 
-                let bezierPath = UIBezierPath(roundedRect: barRect, byRoundingCorners: dataSet.roundedCorners,
+                var roundedCorners = dataSet.roundedCorners
+                if let i = buffer.firstIndex(of: barRect),
+                   let entry = dataSet.entryForIndex(i),
+                   entry.y < 0 {
+                    roundedCorners = dataSet.roundedCornersInverted
+                }
+                let bezierPath = UIBezierPath(roundedRect: barRect, byRoundingCorners: roundedCorners,
                                               cornerRadii: .init(width: dataSet.cornerRadius, height: dataSet.cornerRadius))
                 context.addPath(bezierPath.cgPath)
                 context.drawPath(using: .fill)
@@ -383,7 +389,12 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 context.setFillColor(dataSet.color(atIndex: j).cgColor)
             }
             
-            let bezierPath = UIBezierPath(roundedRect: barRect, byRoundingCorners: dataSet.roundedCorners,
+            var roundedCorners = dataSet.roundedCorners
+            if let entry = dataSet.entryForIndex(j),
+               entry.y < 0 {
+                roundedCorners = dataSet.roundedCornersInverted
+            }
+            let bezierPath = UIBezierPath(roundedRect: barRect, byRoundingCorners: roundedCorners,
                                           cornerRadii: .init(width: dataSet.cornerRadius, height: dataSet.cornerRadius))
             context.addPath(bezierPath.cgPath)
             context.drawPath(using: .fill)
@@ -751,7 +762,11 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 
                 setHighlightDrawPos(highlight: high, barRect: barRect)
                 
-                let bezierPath = UIBezierPath(roundedRect: barRect, byRoundingCorners: set.roundedCorners,
+                var roundedCorners = set.roundedCorners
+                if e.y < 0 {
+                    roundedCorners = set.roundedCornersInverted
+                }
+                let bezierPath = UIBezierPath(roundedRect: barRect, byRoundingCorners: roundedCorners,
                                               cornerRadii: .init(width: set.cornerRadius, height: set.cornerRadius))
                 context.addPath(bezierPath.cgPath)
                 context.drawPath(using: .fill)

--- a/Source/Charts/Renderers/BarChartRenderer.swift
+++ b/Source/Charts/Renderers/BarChartRenderer.swift
@@ -351,7 +351,11 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 guard viewPortHandler.isInBoundsRight(barRect.origin.x) else { break }
 
                 context.setFillColor(dataSet.barShadowColor.cgColor)
-                context.fill(barRect)
+                
+                let bezierPath = UIBezierPath(roundedRect: barRect, byRoundingCorners: dataSet.roundedCorners,
+                                              cornerRadii: .init(width: dataSet.cornerRadius, height: dataSet.cornerRadius))
+                context.addPath(bezierPath.cgPath)
+                context.drawPath(using: .fill)
             }
         }
         
@@ -379,7 +383,10 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 context.setFillColor(dataSet.color(atIndex: j).cgColor)
             }
             
-            context.fill(barRect)
+            let bezierPath = UIBezierPath(roundedRect: barRect, byRoundingCorners: dataSet.roundedCorners,
+                                          cornerRadii: .init(width: dataSet.cornerRadius, height: dataSet.cornerRadius))
+            context.addPath(bezierPath.cgPath)
+            context.drawPath(using: .fill)
             
             if drawBorder
             {
@@ -744,7 +751,10 @@ open class BarChartRenderer: BarLineScatterCandleBubbleRenderer
                 
                 setHighlightDrawPos(highlight: high, barRect: barRect)
                 
-                context.fill(barRect)
+                let bezierPath = UIBezierPath(roundedRect: barRect, byRoundingCorners: set.roundedCorners,
+                                              cornerRadii: .init(width: set.cornerRadius, height: set.cornerRadius))
+                context.addPath(bezierPath.cgPath)
+                context.drawPath(using: .fill)
             }
         }
     }

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -229,7 +229,11 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                 
                 context.setFillColor(dataSet.barShadowColor.cgColor)
                 
-                let bezierPath = UIBezierPath(roundedRect: _barShadowRectBuffer, byRoundingCorners: dataSet.roundedCorners,
+                var roundedCorners = dataSet.roundedCorners
+                if e.x < 0 {
+                    roundedCorners = dataSet.roundedCornersInverted
+                }
+                let bezierPath = UIBezierPath(roundedRect: _barShadowRectBuffer, byRoundingCorners: roundedCorners,
                                               cornerRadii: .init(width: dataSet.cornerRadius, height: dataSet.cornerRadius))
                 context.addPath(bezierPath.cgPath)
                 context.drawPath(using: .fill)
@@ -269,7 +273,12 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                 context.setFillColor(dataSet.color(atIndex: j).cgColor)
             }
 
-            let bezierPath = UIBezierPath(roundedRect: barRect, byRoundingCorners: dataSet.roundedCorners,
+            var roundedCorners = dataSet.roundedCorners
+            if let entry = dataSet.entryForIndex(j),
+               entry.x < 0 {
+                roundedCorners = dataSet.roundedCornersInverted
+            }
+            let bezierPath = UIBezierPath(roundedRect: barRect, byRoundingCorners: roundedCorners,
                                           cornerRadii: .init(width: dataSet.cornerRadius, height: dataSet.cornerRadius))
             context.addPath(bezierPath.cgPath)
             context.drawPath(using: .fill)

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -228,7 +228,11 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                 _barShadowRectBuffer.size.width = viewPortHandler.contentWidth
                 
                 context.setFillColor(dataSet.barShadowColor.cgColor)
-                context.fill(_barShadowRectBuffer)
+                
+                let bezierPath = UIBezierPath(roundedRect: _barShadowRectBuffer, byRoundingCorners: dataSet.roundedCorners,
+                                              cornerRadii: .init(width: dataSet.cornerRadius, height: dataSet.cornerRadius))
+                context.addPath(bezierPath.cgPath)
+                context.drawPath(using: .fill)
             }
         }
         
@@ -265,7 +269,10 @@ open class HorizontalBarChartRenderer: BarChartRenderer
                 context.setFillColor(dataSet.color(atIndex: j).cgColor)
             }
 
-            context.fill(barRect)
+            let bezierPath = UIBezierPath(roundedRect: barRect, byRoundingCorners: dataSet.roundedCorners,
+                                          cornerRadii: .init(width: dataSet.cornerRadius, height: dataSet.cornerRadius))
+            context.addPath(bezierPath.cgPath)
+            context.drawPath(using: .fill)
 
             if drawBorder
             {


### PR DESCRIPTION
### Issue :link:
Many years people needs to fork this repo to implement rounded bars in bar chart.
In pull requests exists also fixing same issue, but my implementation is more configurable

1) You can add corner radius for specific corners only (for example only for topLeft + topRight corner)
2) Corner radius works also for highlight when select bars 

How to use:

 ```
var dataSet = BarChartDataSet(entries: yVals)
dataSet.cornerRadius = 6
dataSet.roundedCorners = .allCorners
        // or
dataSet.roundedCorners = [.topLeft, .topRight]
```

<img width="360" alt="Screenshot 2024-03-29 at 1 15 25" src="https://github.com/ChartsOrg/Charts/assets/7975051/93b57d05-9000-4c47-99f3-c79685890ceb">

