### PR TITLE
Crash when call move view to animated

### DIFF
--- a/Source/Charts/Jobs/ViewPortJob.swift
+++ b/Source/Charts/Jobs/ViewPortJob.swift
@@ -17,11 +17,11 @@ import CoreGraphics
 open class ViewPortJob: NSObject
 {
     internal var point: CGPoint = .zero
-    internal unowned var viewPortHandler: ViewPortHandler
+    internal var viewPortHandler: ViewPortHandler
     internal var xValue = 0.0
     internal var yValue = 0.0
-    internal unowned var transformer: Transformer
-    internal unowned var view: ChartViewBase
+    internal var transformer: Transformer
+    internal var view: ChartViewBase
 
     @objc public init(
         viewPortHandler: ViewPortHandler,


### PR DESCRIPTION
…l even if its strong.

### Issue Link :link:
There is no link publicly available.

### Goals :soccer:

- Fix crash when unwanted crash when show/hide graph too fast.

### Implementation Details :construction:
Unowned variables removed.

### Testing Details :mag:
There are two tabs, one of them contains daily graph, another one is other view, when we switch too fast while animation occurs, there is crash, and I could not find any delegate that move view animated finished.
