### PR TITLE
Add MainActor attribute to ChartViewDelegate.

### DIFF
--- a/Source/Charts/Charts/ChartViewBase.swift
+++ b/Source/Charts/Charts/ChartViewBase.swift
@@ -22,7 +22,7 @@ import AppKit
 #endif
 
 @objc
-public protocol ChartViewDelegate
+@MainActor public protocol ChartViewDelegate
 {
     /// Called when a value has been selected inside the chart.
     ///


### PR DESCRIPTION
### Issue Link :link:
- https://github.com/ChartsOrg/Charts/issues/5178

### Goals :soccer:
This warning might be going to be an error in Swift 6. Need to fix and remove this warning.

### Implementation Details :construction:
By adding this attribute to `ChartViewDelegate`, we explicitly marked it as MainActor. Since UIViewController and UIView also have the MainActor attribute by default, there should be no practical change in behavior.