### PR TITLE
Fix min greater than max iterator

### DIFF
--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -138,6 +138,11 @@ extension BarLineScatterCandleBubbleRenderer.XBounds: Sequence {
         }
         
         public mutating func next() -> Int? {
+            var min = min
+            var max = max
+            if max < min {
+                swap(&min, &max)
+            }
             return self.iterator.next()
         }
     }


### PR DESCRIPTION
Sometimes, the min value is greater than the max value. This discrepancy causes a crash.

