### PR TITLE
Charts/issues/5197 - fixed host app crash by adding a check before ca…

### DIFF
--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -66,7 +66,9 @@ open class BarLineScatterCandleBubbleRenderer: NSObject, DataRenderer
     open func isDrawingValuesAllowed(dataProvider: ChartDataProvider?) -> Bool
     {
         guard let data = dataProvider?.data else { return false }
-        return data.entryCount < Int(CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX)
+        let count = CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX
+        guard count < CGFloat.infinity else { return false }
+        return data.entryCount < Int(count)
     }
 
     /// Class representing the bounds of the current viewport in terms of indices in the values array of a DataSet.

--- a/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
+++ b/Source/Charts/Renderers/BarLineScatterCandleBubbleRenderer.swift
@@ -67,7 +67,7 @@ open class BarLineScatterCandleBubbleRenderer: NSObject, DataRenderer
     {
         guard let data = dataProvider?.data else { return false }
         let count = CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX
-        guard count < CGFloat.infinity else { return false }
+        guard count < CGFloat.infinity, !count.isNaN else { return false }
         return data.entryCount < Int(count)
     }
 

--- a/Source/Charts/Renderers/CombinedChartRenderer.swift
+++ b/Source/Charts/Renderers/CombinedChartRenderer.swift
@@ -162,7 +162,9 @@ open class CombinedChartRenderer: NSObject, DataRenderer
     open func isDrawingValuesAllowed(dataProvider: ChartDataProvider?) -> Bool
     {
         guard let data = dataProvider?.data else { return false }
-        return data.entryCount < Int(CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX)
+        let count = CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX
+        guard count < CGFloat.infinity else { return false }
+        return data.entryCount < Int(count)
     }
 
     /// All sub-renderers.

--- a/Source/Charts/Renderers/CombinedChartRenderer.swift
+++ b/Source/Charts/Renderers/CombinedChartRenderer.swift
@@ -163,7 +163,7 @@ open class CombinedChartRenderer: NSObject, DataRenderer
     {
         guard let data = dataProvider?.data else { return false }
         let count = CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX
-        guard count < CGFloat.infinity else { return false }
+        guard count < CGFloat.infinity, !count.isNaN else { return false }
         return data.entryCount < Int(count)
     }
 

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -615,7 +615,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
     open override func isDrawingValuesAllowed(dataProvider: ChartDataProvider?) -> Bool
     {
         guard let data = dataProvider?.data else { return false }
-        let count = CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX
+        let count = CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleY
         guard count < CGFloat.infinity, !count.isNaN else { return false }
         return data.entryCount < Int(count)
     }

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -614,9 +614,10 @@ open class HorizontalBarChartRenderer: BarChartRenderer
     
     open override func isDrawingValuesAllowed(dataProvider: ChartDataProvider?) -> Bool
     {
-        guard let data = dataProvider?.data
-            else { return false }
-        return data.entryCount < Int(CGFloat(dataProvider?.maxVisibleCount ?? 0) * self.viewPortHandler.scaleY)
+        guard let data = dataProvider?.data else { return false }
+        let count = CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX
+        guard count < CGFloat.infinity else { return false }
+        return data.entryCount < Int(count)
     }
     
     /// Sets the drawing position of the highlight object based on the riven bar-rect.

--- a/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
+++ b/Source/Charts/Renderers/HorizontalBarChartRenderer.swift
@@ -616,7 +616,7 @@ open class HorizontalBarChartRenderer: BarChartRenderer
     {
         guard let data = dataProvider?.data else { return false }
         let count = CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX
-        guard count < CGFloat.infinity else { return false }
+        guard count < CGFloat.infinity, !count.isNaN else { return false }
         return data.entryCount < Int(count)
     }
     

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -589,7 +589,9 @@ open class PieChartRenderer: NSObject, DataRenderer
     open func isDrawingValuesAllowed(dataProvider: ChartDataProvider?) -> Bool
     {
         guard let data = dataProvider?.data else { return false }
-        return data.entryCount < Int(CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX)
+        let count = CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX
+        guard count < CGFloat.infinity else { return false }
+        return data.entryCount < Int(count)
     }
 
     /// draws the hole in the center of the chart and the transparent circle / hole

--- a/Source/Charts/Renderers/PieChartRenderer.swift
+++ b/Source/Charts/Renderers/PieChartRenderer.swift
@@ -590,7 +590,7 @@ open class PieChartRenderer: NSObject, DataRenderer
     {
         guard let data = dataProvider?.data else { return false }
         let count = CGFloat(dataProvider?.maxVisibleCount ?? 0) * viewPortHandler.scaleX
-        guard count < CGFloat.infinity else { return false }
+        guard count < CGFloat.infinity, !count.isNaN else { return false }
         return data.entryCount < Int(count)
     }
 


### PR DESCRIPTION
### Issue Link :link:
Link to issue: https://github.com/ChartsOrg/Charts/issues/5197

### Goals :soccer:
Fix the crash of the host app from within the library code whenever you get in a situation where the CGFloat calculated in the renderers' isDrawingValuesAllowed function are equal to CGFloat.infinity or to CGFloat.nan, as type casting those causes a crash.

### Implementation Details :construction:
Honestly it's pretty self explanatory and it's rather a dumb-value check, nothing crazy or complicated. The issue explains it all already.

### Testing Details :mag:
I didn't add any tests, as there's no point in testing something that i added because if fails at the compiler level so i don't think any tests are required, but please let me know.