### PR TITLE
Declare `autoScale` as `open`

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -299,7 +299,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
     private var _autoScaleLastHighestVisibleX: Double?
     
     /// Performs auto scaling of the axis by recalculating the minimum and maximum y-values based on the entries currently in view.
-    internal func autoScale()
+    open func autoScale()
     {
         guard let data = data
             else { return }


### PR DESCRIPTION
### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
Open up the `autoScale` method so that additional operations can be performed while auto scaling.

Our usage is this:

```swift
override func autoScale() {
    super.autoScale()
    notifyDataSetChanged()
}
```

We have enabled auto scaling and there are additional elements in the graph that rely on `notifyDataSetChanged` being called. We have maintained our own fork for this sole change, but if it's not too controversial, it would be nice to merge this change upstream.

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
Nothing special, just declare the method as `open` instead of `internal`.

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
I don't think any tests are relevant here.