### PR TITLE
Fix crash in LineChartRenderer.swift when animating data set changes

### DIFF
--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -760,6 +760,12 @@ open class LineChartRenderer: LineRadarRenderer
         
         for high in indices
         {
+            // When updating the data set for the chart and then animating it, sometimes highlights are generated for the
+            // removed sets. This guard prevents OOB in the case where the new set has less data than the old set
+            if high.dataSetIndex >= lineData._dataSets.count - 1 {
+                continue
+            }
+            
             guard let set = lineData[high.dataSetIndex] as? LineChartDataSetProtocol,
                   set.isHighlightEnabled
             else { continue }


### PR DESCRIPTION
When updating the data set for the chart and then animating it, sometimes highlights are generated for the
            // removed sets. This guard prevents OOB in the case where the new set has less data than the old set

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
Fix crash when updating datasets and animating